### PR TITLE
Corrigindo problema da tabela de sugestão.

### DIFF
--- a/assets/api-pagueibarato-db.sql
+++ b/assets/api-pagueibarato-db.sql
@@ -106,7 +106,7 @@ CREATE TABLE sugestao
     "estoqueId" integer NOT NULL,
     "criadoPor" integer NOT NULL,
     CONSTRAINT sugestao_pkey PRIMARY KEY (id),
-    CONSTRAINT "sugestao_estoqueId_fkey" FOREIGN KEY (id)
+    CONSTRAINT "sugestao_estoqueId_fkey" FOREIGN KEY ("estoqueId")
         REFERENCES estoque (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION,


### PR DESCRIPTION
A tabela sugestão estava com uma foreign key referenciando a coluna local errada. Ao invés de referenciar a coluna "estoqueId", estava fazendo referência à coluna "id", que é serial. Desse modo, sempre que uma sugestão era adicionada, o banco de dados tentava procurar o id da sugestão gerado lá na tabela de estoque.

À princípio os ids gerados pela tabela sugestão estavam batendo com aqueles presentes na tabela estoque, por isso o erro não foi notado.